### PR TITLE
Include search score in results.

### DIFF
--- a/lib/musicbrainz.js
+++ b/lib/musicbrainz.js
@@ -1180,6 +1180,8 @@ mb.searchReleases = function (query, filter, force, callback) {
 
 				//release.readData(linkedEntities, data);
 
+				release.searchScore = parseInt(data[i]['@']['ext:score'], 10);
+
 				release._loaded = true;
 
 				releases.push(release);
@@ -1239,6 +1241,9 @@ mb.searchRecordings = function (query, filter, force, callback) {
 				}
 
 				//recording.readData(linkedEntities, data);
+
+				recording.searchScore = parseInt(data[i]['@']['ext:score'], 10);
+
 				recording._loaded = true;
 				recordings.push(recording);
 			}
@@ -1280,6 +1285,9 @@ mb.searchArtists = function (query, filter, force, callback) {
 				}
 
 				//artist.readData(linkedEntities, data);
+
+				artist.searchScore = parseInt(artistList[i]['@']['ext:score'], 10);
+
 				artist._loaded = true;
 				artists.push(artist);
 			}

--- a/test/test.js
+++ b/test/test.js
@@ -280,6 +280,14 @@ describe('mb', function() {
 			});
 		});
 
+		it('should include search score in results', function (done) {
+			mb.searchReleases( 'Option Paralysis', {}, function (err, result) {
+				expect(result).to.be.instanceof(Array);
+				expect(result[0].searchScore).to.eql(100);
+				done();
+			});
+		});
+
         it('should return a release even with special characters in the name', function(done) {
             mb.searchReleases( testReleaseSpecialCharsQuery, {}, function (err, result) {
 				if (err) { throw err; }
@@ -322,6 +330,13 @@ describe('mb', function() {
 			});
 		});
 
+		it('should include search score in results', function(done) {
+			mb.searchRecordings( 'Black Bubblegum', {}, function (err, result) {
+				expect(result).to.be.instanceof(Array);
+				expect(result[0].searchScore).to.eql(100);
+				done();
+			});
+		});
 	});
 
 
@@ -354,6 +369,13 @@ describe('mb', function() {
 			});
 		});
 
+		it('should include search score in results', function (done) {
+			mb.searchArtists( 'The Dillinger Escape Plan', {}, function (err, result) {
+				expect(result).to.be.instanceof(Array);
+				expect(result[0].searchScore).to.eql(100);
+				done();
+			});
+		});
 	});
 
 });


### PR DESCRIPTION
Results from search for recordings / releases / artists includes an `ext:score` attribute on the top level element of each result. This data is useful for certain applications, so I've updated the search methods to include it in the modelled results.
