### PR TITLE
Support artist-credits nested in recordings nested in releases

### DIFF
--- a/lib/musicbrainz.js
+++ b/lib/musicbrainz.js
@@ -195,7 +195,7 @@ var RecordingLinkedEntities = function () {
 		return null;
 	};
 
-	this.loadMediumList = function (data) {
+	this.loadMediumList = function (data, linkedEntities) {
 		if (typeof data['medium-list'] !== 'undefined') {
 			var mediums = data['medium-list'].medium;
 			if (data['medium-list']['@'].count <= 1) mediums = [mediums];
@@ -233,6 +233,8 @@ var RecordingLinkedEntities = function () {
 							var recording = new Recording(tracks[j].recording['@'].id);
 							recording.setProperty('title', tracks[j].recording.title);
 							recording.setProperty('length', tracks[j].recording.length);
+
+							recording.readData(linkedEntities, tracks[j].recording);
 
 							track.recording = recording;
 						}
@@ -318,6 +320,7 @@ var ArtistLinkedEntities = function () {
 	};
 
 	this._readDataFunctions['artists'] = this.loadArtistCredits;
+	this._readDataFunctions['artist-credits'] = this.loadArtistCredits;
 
 	return this;
 };
@@ -577,7 +580,7 @@ var Resource = function (mbid) {
 	this.readData = function (linkedEntities, data) {
 		for (var i in linkedEntities) {
 			if (typeof this._readDataFunctions[linkedEntities[i]] === 'function') {
-				this._readDataFunctions[linkedEntities[i]](data);
+				this._readDataFunctions[linkedEntities[i]](data, linkedEntities);
 			}
 		}
 	};


### PR DESCRIPTION
... What a mouthful!

Musicbrainz lets you do things like this:

http://musicbrainz.org/ws/2/release/94cadd69-54b5-40ee-8e53-7fbbd82654d3?inc=artist-credits+recordings+media

The library currently didn't support this correctly. It still mostly doesn't, I just fixed the one place I needed it to work in, but you could apply this elsewhere too I think.
